### PR TITLE
Added command line option to force palette output to 8-bits.

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ gfx2next [options] &lt;srcfile&gt; [&lt;dstfile&gt;]
 |-pal-full|Generate the full palette for -colors-4bit mode|
 |-pal-std|If specified, convert to the Spectrum Next standard palette colors. This option is ignored if the -colors-4bit option is given|
 |-pal-none|No raw palette is created|
+|-pal-rgb332|Force 8-bit palette output|
 |-zx0|Compress all data using zx0|
 |-zx0-screen|Compress screen data using zx0|
 |-zx0-bitmap|Compress bitmap data using zx0|

--- a/src/gfx2next.c
+++ b/src/gfx2next.c
@@ -1314,6 +1314,7 @@ static void create_filename(char *out_filename, const char *in_filename, const c
 
 static void create_series_filename(char *out_filename, const char *in_filename, const char *extension, bool use_compression, int index)
 {
+	char temp_filename[256] = { 0 };
 	char *start = strrchr(in_filename, DIR_SEPERATOR_CHAR);
 	
 	strcpy(out_filename, start == NULL ? in_filename : start + 1);
@@ -1321,8 +1322,10 @@ static void create_series_filename(char *out_filename, const char *in_filename, 
 	char *end = strchr(out_filename, '.');
 	out_filename[end == NULL ? strlen(out_filename) : (int)(end - out_filename)] = '\0';
 
-	snprintf(out_filename, 255, "%s_%d%s", out_filename, index, extension);
+	snprintf(temp_filename, 255, "%s_%d%s", out_filename, index, extension);
 	
+	strcpy(out_filename, temp_filename);
+
 	if (use_compression)
 		strcat(out_filename, EXT_ZX0);
 }


### PR DESCRIPTION
Added a new command line option -pal-rgb332 to force the palette output to be 8-bits (RGB332) instead of 9-bits (RGB332+B1).
Also addresses a couple of compiler warnings when compiling with gcc 9.3 on Ubuntu 20.04.

Nice Easter egg ;)