### PR TITLE
Added math library to compilation command line.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ ZIP := zip -r -q
 
 all:
 	$(MKDIR) bin
-	gcc -O2 -Wall -o bin/gfx2next src/lodepng.c src/zx0.c src/gfx2next.c
+	gcc -O2 -Wall -o bin/gfx2next src/lodepng.c src/zx0.c src/gfx2next.c -lm
 
 distro:
 	$(MAKE) clean all


### PR DESCRIPTION
Math library is required to resolve sqrt() and round() on Ubuntu 20.04 and gcc 9.3.

Feel free to reject this if it breaks other build platforms.
IH.