### PR TITLE
Resolve compiler warning due to differences between MinGW and Linux.

### DIFF
--- a/src/gfx2next.c
+++ b/src/gfx2next.c
@@ -3656,7 +3656,7 @@ int main(int argc, char *argv[])
 		}
 
 		// success, output found filenames
-		printf("Found %lu filename matches\n", gstruct.gl_pathc);
+		printf("Found %u filename matches\n", (unsigned) gstruct.gl_pathc);
 		filename = gstruct.gl_pathv;
 		
 		if (m_args.asm_start_auto)


### PR DESCRIPTION
__SIZE_TYPE__ is defined differently between MinGW and Linux. This in
not an elegant solution but it does resolve the warning.