### PR TITLE
Fixed issues processing Tiled (.tmx) files

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ gcc -O2 -Wall -o bin/gfx2next src/lodepng.c src/zx0.c src/gfx2next.c -lm
 ## Credits
 
 * Ben Baker - [Gfx2Next](https://www.rustypixels.uk/?page_id=976) Author & Maintainer
-* [Craig Hackney](https://github.com/iratahack) - Added -pal-rgb332 option and fixes
+* [Craig Hackney](https://github.com/iratahack) - Added -pal-rgb332 & -pal-bgr222, -colors-1bit, and -map-sms options and some fixes
 * Einar Saukas - [ZX0](https://github.com/einar-saukas/ZX0)
 * Jim Bagley - NextGrab / MapGrabber
 * Juan J. Martinez - [png2scr](https://github.com/reidrac/png2scr)

--- a/src/gfx2next.c
+++ b/src/gfx2next.c
@@ -1381,7 +1381,7 @@ static void create_filename(char *out_filename, const char *in_filename, const c
 	
 	strcpy(out_filename, start == NULL ? in_filename : start + 1);
 
-	char *end = strchr(out_filename, '.');
+	char *end = strrchr(out_filename, '.');
 	end = (end == NULL ? out_filename + strlen(out_filename) : end);
 
 	strcpy(end, extension);
@@ -3399,14 +3399,14 @@ static void parse_tile(char *line, int first_gid, int *tile_count)
 	
 	while (pch != NULL)
 	{
-		uint32_t tile_id = atoi(pch);
+		uint32_t tile_id = atoi(pch) - first_gid;
 		
 		if (tile_id == -1)
 			tile_id = m_args.tiled_blank;
 		
 		uint8_t attributes = tiled_flags_to_attributes(tile_id >> 28);
 
-		m_map[(*tile_count)++] = ((tile_id & TILED_TILEID_MASK) - first_gid) | (attributes << 8);
+		m_map[(*tile_count)++] = (tile_id & TILED_TILEID_MASK) | (attributes << 8);
 		
 		pch = strtok(NULL, ",\r\n");
 	}
@@ -3577,7 +3577,7 @@ int process_file()
 	
 	if (p_ext != NULL)
 	{
-		if (strcasecmp(p_ext, ".tmx") == 0)
+		if (strcasecmp(p_ext, EXT_TMX) == 0)
 		{
 			m_args.tiled = true;
 			

--- a/src/gfx2next.c
+++ b/src/gfx2next.c
@@ -38,7 +38,7 @@ int _CRT_glob = 0;
 #include "zx0.h"
 #include "lodepng.h"
 
-#define VERSION						"1.1.5"
+#define VERSION						"1.1.6"
 
 #define DIR_SEPERATOR_CHAR			'\\'
 


### PR DESCRIPTION
I ran into a couple of issues while processing .tmx files.

* create_filename() was calling strchr(), this caused the dot's in relative paths to be taken as the dot before the extension. It has been changed to strrchr() which will search for the dot before the extension starting from the end of the string.
* Need to subtract first_gid before checking for -1 to specify the blank tile id.

Cheers,
IH.