### PR TITLE
Makefile: add `install` target and improve others

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,8 @@
 # Makefile for compiling gfx2next
 ################################################################################
 
+.PHONY: all install distro clean
+
 MKDIR := mkdir -p
 
 RM := rm -rf
@@ -12,20 +14,36 @@ CP := cp
 
 ZIP := zip -r -q
 
-all:
-	$(MKDIR) bin
-	gcc -O2 -Wall -o bin/gfx2next src/lodepng.c src/zx0.c src/gfx2next.c -lm
+BIN_DIR := bin
 
-distro:
-	$(MAKE) clean all
-	$(RM) tmp
-	$(MKDIR) tmp/gfx2next
-	$(CP) bin/* tmp/gfx2next
-	$(CP) src/* tmp/gfx2next
-	$(CP) README.md tmp/gfx2next
+TMP_DIR := tmp
+
+EXE_BASE_NAME := gfx2next
+
+EXE_FULL_NAME := $(BIN_DIR)/$(EXE_BASE_NAME)
+
+# common GNU variables related to install location
+prefix ?= /usr/local
+exec_prefix ?= $(prefix)
+bindir ?= $(exec_prefix)/bin
+
+all: $(EXE_FULL_NAME)
+
+install: $(EXE_FULL_NAME)
+	$(CP) $^ $(bindir)/$(^F)
+
+distro: clean
+	$(MAKE) all
+	$(MKDIR) $(TMP_DIR)/gfx2next
+	$(CP) $(BIN_DIR)/* $(TMP_DIR)/gfx2next
+	$(CP) src/* $(TMP_DIR)/gfx2next
+	$(CP) README.md $(TMP_DIR)/gfx2next
 	$(RM) build/gfx2next.zip
-	cd tmp; $(ZIP) ../build/gfx2next.zip gfx2next
-	$(RM) tmp
+	cd $(TMP_DIR); $(ZIP) ../build/gfx2next.zip gfx2next
 
 clean:
-	$(RM) bin tmp
+	$(RM) $(BIN_DIR) $(TMP_DIR)
+
+$(EXE_FULL_NAME): src/lodepng.c src/zx0.c src/gfx2next.c
+	$(MKDIR) $(@D)
+	gcc -O2 -Wall -o $@ $^ -lm


### PR DESCRIPTION
IMHO it's a bit more correct this way (in subtle ways, like `make distro` with original Makefile does for me delete bin/ multiple times, the tmp/ is removed by `clean` so why should `distro` delete it as last step, etc...

But feels like the Makefile become lot longer, so up to you, whether you like it like this, or prefer simpler Makefile.

(some of the changes scratch my personal itch about installing tool binaries to ~/.local/bin, so with this change I can do `make prefix=~/.local install` to build+install the binary, other changes are "cleanup" and not directly connected to this goal)