### PR TITLE
remove creating original image preview along every tile/sprite/bank data write

### DIFF
--- a/src/gfx2next.c
+++ b/src/gfx2next.c
@@ -2546,7 +2546,7 @@ static void write_next_bitmap()
 			else
 				p_image = get_bank(m_next_image + m_bank_count * m_bank_size, bank_size);
 			
-			write_next_bitmap_file(bitmap_file, m_bitmap_filename, p_image, bank_size, m_args.compress & COMPRESS_BITMAP);
+			write_file(bitmap_file, m_bitmap_filename, p_image, bank_size, false, m_args.compress & COMPRESS_BITMAP);
 			
 			fclose(bitmap_file);
 
@@ -2664,7 +2664,7 @@ static void write_tiles_sprites()
 				exit_with_msg("Can't create file %s.\n", out_filename);
 			}
 			
-			write_next_bitmap_file(p_file, out_filename, &m_tiles[m_bank_count * m_bank_size], bank_size, use_compression);
+			write_file(p_file, out_filename, &m_tiles[m_bank_count * m_bank_size], bank_size, false, use_compression);
 			
 			fclose(p_file);
 
@@ -2696,7 +2696,7 @@ static void write_tiles_sprites()
 			exit_with_msg("Can't create file %s.\n", out_filename);
 		}
 
-		write_next_bitmap_file(p_file, out_filename, m_tiles, data_size, use_compression);
+		write_file(p_file, out_filename, m_tiles, data_size, false, use_compression);
 		
 		if (m_args.preview)
 		{

--- a/src/gfx2next.c
+++ b/src/gfx2next.c
@@ -2910,27 +2910,12 @@ static void write_map(uint32_t image_width, uint32_t image_height, uint32_t tile
 
 static match_t check_tile(int i)
 {
-	match_t match = MATCH_XY;
+	uint32_t tile_byte_size = m_args.colors_4bit ? (m_tile_size >> 1) : m_args.colors_1bit ? (m_tile_size >> 3) : m_tile_size;
 	
-	for (int j = 0; j < m_tile_size; j++)
-	{
-		int ti = i * m_tile_size + j;
-		int index = m_tile_count * m_tile_size + j;
-		
-		if (m_args.colors_4bit)
-		{
-			ti >>= 1;
-			index >>= 1;
-		}
-		
-		if (m_tiles[ti] != m_tiles[index])
-		{
-			match &= ~MATCH_XY;
-			break;
-		}
-	}
+	int i_offset = i * tile_byte_size;
+	int new_tile_offset = m_tile_count * tile_byte_size;
 	
-	return match;
+	return memcmp(m_tiles + i_offset, m_tiles + new_tile_offset, tile_byte_size) ? MATCH_NONE : MATCH_XY;
 }
 
 static match_t check_tile_rotate(int i)
@@ -3355,7 +3340,7 @@ static void process_tiles()
 						uint32_t ti = m_args.tile_offset + get_tile(x * m_tile_width, y * m_tile_height, &attributes);
 						uint16_t map_mask = (m_args.map_16bit ? 0x1ff : 0xff);
 						
-						m_map[y * (m_image_width / m_tile_width) + x] = (ti & map_mask) | (attributes << 8);
+						m_map[y * map_width + x] = (ti & map_mask) | (attributes << 8);
 					}
 					else
 					{


### PR DESCRIPTION
only writing next-image as whole should produce the preview png