### PR TITLE
adding Cirrus CI task script, preparing to test CI setup

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,35 @@
+task:
+  name: Linux gcc 9/latest builds
+  env:
+    CIRRUS_CLONE_DEPTH: 1
+  container:
+    matrix:
+      image: gcc:9
+      image: gcc:latest
+    cpu: 2
+    memory: 1G
+  build_script: make clean && make -j3
+  install_script: make install && make clean
+  ## now try the built+installed gfx2next with some tests
+  # this is not separate task, because that would need again build
+  # of sjasmplus in new container instance, so just do everything in one task
+  # TODO after adding some tests: tests_script: make tests
+
+task:
+  name: MacOS default CC build (with unit tests)
+  env:
+    CIRRUS_CLONE_DEPTH: 1
+  macos_instance:
+    image: ghcr.io/cirruslabs/macos-monterey-base:latest
+  #sw_versions2_script:
+    #- git --version || echo "no git"
+    #- bash --version || echo "no bash"
+    #- make --version || echo "no make"
+    #- cc --version || echo "no cc"
+    #- c++ --version || echo "no c++"
+  build_script:
+    - date
+    - make clean && make -j10 CC=cc
+  # TODO after adding some tests: test_script: make clean && make -j10 CC=cc tests
+
+# TODO: add some tests, either through custom bash script runner, or makefile or CMake even

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,8 @@
 
 .PHONY: all install distro clean
 
+CC := gcc
+
 MKDIR := mkdir -p
 
 RM := rm -rf
@@ -46,4 +48,4 @@ clean:
 
 $(EXE_FULL_NAME): src/lodepng.c src/zx0.c src/gfx2next.c
 	$(MKDIR) $(@D)
-	gcc -O2 -Wall -o $@ $^ -lm
+	$(CC) -O2 -Wall -o $@ $^ -lm


### PR DESCRIPTION
Setup Cirrus CI for your repo **first**:

Visit github marketplace for their app: https://github.com/marketplace/cirrus-ci
And choose your plan (Public repositories $0)

During "installation" configure it to only allowed public repositories and add headkaze/Gf2xNext repo to the list

![image](https://user-images.githubusercontent.com/236664/178116458-a43f7be4-db91-47c9-b13f-bf3ca8baab4b.png)

Then merge this pull request, and first CI build should be done shortly.

Quick start docs for Cirrus:
https://cirrus-ci.org/guide/quick-start/

To check cirrus builds logs/progress in their native web interface, use https://cirrus-ci.com/ and log with your github account, you should see there list of all builds done recently and active repos involved.